### PR TITLE
Fixing Workflows and Improvements

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: docs
+          ref: ${{ github.head_ref || 'main' }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - docs
       - main
+      - workflows
     paths:
       - .github/workflows/build-docs.yml
       - website/**
@@ -31,7 +32,7 @@ jobs:
           npm install
           npm run build
       - name: Upload Build As Artifact
-        uses: upload-pages-artifact@v1.0.8
+        uses: actions/upload-pages-artifact@v1.0.8
         with:
           name: 'github-pages'
           path: 'website/build'

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -4,9 +4,8 @@ on:
     branches:
       - main
   push:
-    branches-ignore: 
-     - docs
-     - github-action-setup
+    branches: 
+     - main
   workflow_dispatch:
 jobs:
   jest:

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -4,6 +4,12 @@ permissions:
   packages: read
 on:
   workflow_dispatch:
+    inputs:
+      shouldBumpVersion:
+        description: 'Should this workflow bump the version of package.json?'
+        default: false
+        type: boolean
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -11,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-plugin
       - uses: phips28/gh-action-bump-version@v9.1.0
+        if: ${{ inputs.shouldBumpVersion }}
         with:
           version-type: patch
           skip-tag: true


### PR DESCRIPTION
Added workflow input to set the choice for version bump.
Now build-docs.yml only from artifact based official plugins.
Testing now triggers only on pr and push on main.